### PR TITLE
SDD Hierarchy Fix

### DIFF
--- a/geometry/sdd.gdml
+++ b/geometry/sdd.gdml
@@ -44,6 +44,9 @@
         <!-- Silicon Sensort -->
         <tube name="sddDetectorSolid" rmax="4.0" z="0.470" deltaphi="360" lunit="mm" aunit="degree" />
 
+        <!-- MINIWORLD Volume -->
+        <tube name="sddWorld" rmax="7.5" z="10.0" deltaphi="360" lunit="mm" aunit="degree" />
+
         <!-- Combine the solids using unions and transformations -->
         <!-- Union of TopCone and InnerCylinder -->
         <union name="TopConeWithInnerCylinder">
@@ -76,9 +79,15 @@
         </volume>
 
         <!-- Create the logical Volume of the casing -->
-        <volume name="sddLogical">
+        <volume name="sddCaseLogical">
             <materialref ref="G4_Al" />
             <solidref ref="sddCaseSolid" />
+        </volume>
+
+        <!-- MINI World Volume -->
+        <volume name="VITUS">
+            <materialref ref="G4_Galactic" />
+            <solidref ref="sddWorld" />
             <physvol>
                 <volumeref ref="sddWindowLogical" />
                 <positionref ref="WindowPosition" />
@@ -87,11 +96,14 @@
                 <volumeref ref="detectLogical" />
                 <positionref ref="DetectorPosition" />
             </physvol>
+            <physvol>
+                <volumeref ref="sddCaseLogical" />
+            </physvol>
         </volume>
     </structure>
 
-    <setup name="SDD" version="1.0">
-        <world ref="sddLogical" />
+    <setup name="Default" version="1.0">
+        <world ref="VITUS" />
     </setup>
 
 </gdml>

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -169,7 +169,7 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
     // Read the file 
     // (the `false` flag turns off the check to make sure the GDML file is properly formatted)
-    parser->Read(DETECTOR_GDML_FILENAME,false);
+    parser->Read(DETECTOR_GDML_FILENAME,true);
 
     // Extract the logical volume of the sensitive part of the detector
     detectLogical = parser->GetVolume("detectLogical");
@@ -179,9 +179,10 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
     G4VisAttributes*    detectColor     = new G4VisAttributes(true,G4Color(0.00, 0.00, 0.80, 0.4));
     G4VisAttributes*    windowColor     = new G4VisAttributes(true,G4Color(0.68, 0.93, 0.93, 0.2));
     G4VisAttributes*    caseColor       = new G4VisAttributes(true,G4Color(0.72, 0.54, 0.04, 0.4));
+    G4VisAttributes*    containerColor  = new G4VisAttributes(false,G4Color(0.72, 0.54, 0.04, 0.4));
     G4RotationMatrix*   detectRotation  = new G4RotationMatrix(detectPostition.cross(G4ThreeVector(0., 0., -1.)).unit(),90*degree);
-    G4LogicalVolume*    sddLogical      = parser->GetVolume("sddLogical");
-    G4VPhysicalVolume*  detectPhysical  = new G4PVPlacement(
+    G4LogicalVolume*    sddLogical      = parser->GetVolume("VITUS");
+    G4VPhysicalVolume*  sddPhysical     = new G4PVPlacement(
         detectRotation,                 // Rotation Matrix
         detectPostition,                // Position of center
         sddLogical,                     // Logical Volume to place
@@ -194,8 +195,9 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
     // Add some colors
     if (parser->GetVolume("sddWindowLogical")) parser->GetVolume("sddWindowLogical")->SetVisAttributes(windowColor);
-    parser->GetVolume("sddLogical")->SetVisAttributes(caseColor);
+    parser->GetVolume("sddCaseLogical")->SetVisAttributes(caseColor);
     parser->GetVolume("detectLogical")->SetVisAttributes(detectColor);
+    sddLogical->SetVisAttributes(containerColor);
 
     #endif
 


### PR DESCRIPTION
Fixed the SDD not registering events by changing the hierarchy of the GDML file. In particular a fake worldvolume was in introduced that is made out of Vacuum. This way everything was identified properly. 