### PR TITLE
New geom fix

### DIFF
--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -60,7 +60,7 @@ RunAction::~RunAction()
 {
     // If you are running in parallel mode delete the table merger
     #ifdef MPI_ENABLE
-    delete ntupleMerger;
+    // delete ntupleMerger;
     #endif
 }
 

--- a/src/RunAction.cc
+++ b/src/RunAction.cc
@@ -29,12 +29,14 @@ RunAction::RunAction()
 {
     // If you are in parallel mode set up how to merge the files
     #ifdef MPI_ENABLE
+	// (This might have been an oopsie by me SORRY! -Panos)
+	/////////////////////////////////////////////////////////
     // Sets the merging of Ntuples for MPI
-    if (G4MPImanager::GetManager()->GetTotalSize() >= 2) {
-        G4int numberOfReducedNtupleFiles    = 0;
-        G4bool rowWise                      = true;
-        ntupleMerger    = new G4MPIntupleMerger(numberOfReducedNtupleFiles, rowWise);
-    }
+    // if (G4MPImanager::GetManager()->GetTotalSize() >= 2) {
+    //     G4int numberOfReducedNtupleFiles    = 0;
+    //     G4bool rowWise                      = true;
+    //     ntupleMerger    = new G4MPIntupleMerger(numberOfReducedNtupleFiles, rowWise);
+    // }
 
     // Enable table merging
     G4bool mergeNtuple  = false;


### PR DESCRIPTION
Ok so I think the problem was that the simulation when compiled with MPI might not even try to merge data together, but even creating the merger might attempt to create extra workers even though we told it not to.

So I commented out its creation anyway hehe. It was unused in the rest simulation so it shouldn't change anything. I am still not sure if this means that data were not lost in the previous runs. I guess the way to find out, is to run this version, and check if you get the correct number of files and the number of particles detected is roughly the same as the previous runs. 

If you're comfortable @sandhya-sharrmma you can merge this, or build and run this branch instead in Jubail to see what's up!